### PR TITLE
👥 Remove author from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build": "node src/builder",
     "semantic-release": "semantic-release"
   },
-  "author": "ilyasmez",
   "devDependencies": {
     "camelcase": "^6.2.0",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Seems like [semantic-release/git](https://github.com/semantic-release/git) grab the release author from the `author` attribute in package.json
I've removed it to see if it will fallback to `@semantic-release-bot` as mentioned in the docs, and also because I don't like to have an author for non-personal projects :)