### PR TITLE
🔧 Bring back the `main` entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "homeday-assets",
   "version": "0.0.0-development",
   "description": "A library of Homeday's icons and illustrations, meant to be used inside Homeday's products.",
+  "main": "./assets/index.js",
   "module": "./assets/index.js",
   "sideEffects": false,
   "repository": {

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -26,6 +26,7 @@ async function copyPackageJson() {
   // We adjust the main/entry file to match the new structure
   const newPackageJson = {
     ...packageJson,
+    main: './index.js',
     module: './index.js',
   };
 


### PR DESCRIPTION
A followup to: #5
Actually, the `main` entry would be still needed when the app is not being built for production... for example when running tests.