### PR TITLE
🐛 Fix author identity unknown error 

### DIFF
--- a/.github/workflows/sync-repo.yml
+++ b/.github/workflows/sync-repo.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+      - name: Setup git config
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
       - name: Read .nvmrc 🔍
         run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
         id: nvm


### PR DESCRIPTION
In this PR I added a new step to setup git config in [the sync-repo GH action workflow](https://github.com/homeday-de/homeday-assets/blob/master/.github/workflows/sync-repo.yml) to fix author identity unknown error even though git config is already properly set.