### PR TITLE
🔧 Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @homeday-de/frontend 


### PR DESCRIPTION
## Main changes
- Add `CODEOWNERS` according to the latest Homeday teams setup.